### PR TITLE
Auto-merge sync-from-upstream PRs

### DIFF
--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -60,6 +60,7 @@ jobs:
           claude -p "There are git merge conflicts from merging upstream/main into this fork's main branch. Resolve all conflicts by keeping changes from both sides when possible. For package.json, preserve both upstream additions and fork-specific customizations (like build:sdk). After resolving, stage all files with 'git add .' and commit with 'git commit --no-edit'." --allowedTools "Bash(git*)" "Bash(cat*)" "Bash(grep*)" "Edit" "Read"
 
       - name: Create PR with resolved conflicts
+        id: create-pr
         if: steps.merge.outcome == 'failure'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -67,9 +68,18 @@ jobs:
           BRANCH="auto-sync-upstream-$(date +%Y%m%d%H%M%S)"
           git checkout -b "$BRANCH"
           git push origin "$BRANCH"
-          gh pr create \
+          PR_URL=$(gh pr create \
             --repo GeorgeZhiXu/claudecodeui \
             --title "Auto-sync upstream (conflicts resolved by Claude Code)" \
-            --body "Automated merge from \`upstream/main\` had conflicts that were resolved by Claude Code. Please review the resolutions before merging." \
+            --body "Automated merge from \`upstream/main\` had conflicts that were resolved by Claude Code." \
             --base main \
-            --head "$BRANCH"
+            --head "$BRANCH")
+          echo "pr_url=$PR_URL" >> "$GITHUB_OUTPUT"
+
+      - name: Auto-merge PR
+        if: steps.merge.outcome == 'failure' && steps.create-pr.outcome == 'success'
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr merge "${{ steps.create-pr.outputs.pr_url }}" --merge --delete-branch

--- a/.sdegen/verification.yaml
+++ b/.sdegen/verification.yaml
@@ -1,0 +1,11 @@
+# Verification configuration for SDEGen
+# This task (GH-14) modifies only .github/workflows/sync-upstream.yml
+# No application source code is changed, so build/test verification is not applicable.
+
+verification:
+  # No build or test steps needed for workflow-only changes
+  steps: []
+
+  non_blocking:
+    - name: "N/A — workflow-only change"
+      reason: "No baseline verification needed; this task modifies only a GitHub Actions YAML file, not application source code."


### PR DESCRIPTION
## Summary
- Adds auto-merge step to the sync-upstream workflow so that conflict-resolved PRs are automatically merged after creation
- Captures the PR URL from the create step and passes it to a new `Auto-merge PR` step via `GITHUB_OUTPUT`
- Simplifies the PR body text (removes redundant review instruction)

## Test plan
- [ ] Verify the workflow YAML is valid by triggering a dry run or reviewing in the Actions tab
- [ ] Confirm that when upstream merge has conflicts, the PR is created and then auto-merged
- [ ] Confirm `continue-on-error: true` on the merge step prevents workflow failure if auto-merge is not possible