### PR TITLE
fix: improve sync-upstream workflow error handling

### DIFF
--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -12,6 +12,7 @@ concurrency:
 permissions:
   contents: write
   pull-requests: write
+  workflows: write
 
 jobs:
   sync:

--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -77,9 +77,15 @@ jobs:
           echo "pr_url=$PR_URL" >> "$GITHUB_OUTPUT"
 
       - name: Auto-merge PR
+        id: auto-merge
         if: steps.merge.outcome == 'failure' && steps.create-pr.outcome == 'success'
         continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh pr merge "${{ steps.create-pr.outputs.pr_url }}" --merge --delete-branch
+
+      - name: Log auto-merge failure
+        if: steps.auto-merge.outcome == 'failure'
+        run: |
+          echo "::warning::Auto-merge failed for PR ${{ steps.create-pr.outputs.pr_url }}. The PR remains open for manual review."


### PR DESCRIPTION
## Summary
- Add `workflows: write` permission to allow the sync-upstream action to function correctly
- Add an `id` to the auto-merge step and a follow-up logging step so that auto-merge failures produce a visible warning instead of silently failing
- The PR remains open for manual review when auto-merge cannot complete

## Test plan
- [ ] Verify the sync-upstream workflow triggers correctly on schedule/manual dispatch
- [ ] Confirm auto-merge failure produces the expected `::warning::` annotation