### PR TITLE
fix: use PAT for sync-upstream workflow file updates

### DIFF
--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -13,6 +13,11 @@ permissions:
   contents: write
   pull-requests: write
 
+# SYNC_PAT secret required: a Personal Access Token (classic) with `repo` and
+# `workflow` scopes, or a fine-grained PAT with Contents + Workflows read-write.
+# Without it, pushes that include .github/workflows/ file changes will fail
+# because GITHUB_TOKEN cannot create or update workflow files.
+# Add the secret via: GitHub repo Settings > Secrets and variables > Actions.
 jobs:
   sync:
     runs-on: ubuntu-latest
@@ -22,6 +27,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ secrets.SYNC_PAT || github.token }}
 
       - name: Configure git
         run: |
@@ -63,7 +69,7 @@ jobs:
         id: create-pr
         if: steps.merge.outcome == 'failure'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.SYNC_PAT || secrets.GITHUB_TOKEN }}
         run: |
           BRANCH="auto-sync-upstream-$(date +%Y%m%d%H%M%S)"
           git checkout -b "$BRANCH"
@@ -81,7 +87,7 @@ jobs:
         if: steps.merge.outcome == 'failure' && steps.create-pr.outcome == 'success'
         continue-on-error: true
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.SYNC_PAT || secrets.GITHUB_TOKEN }}
         run: |
           gh pr merge "${{ steps.create-pr.outputs.pr_url }}" --merge --delete-branch
 


### PR DESCRIPTION
## Summary
- Uses `SYNC_PAT` (Personal Access Token with `workflow` scope) instead of `GITHUB_TOKEN` for checkout and PR operations in the sync-upstream workflow
- Resolves the `remote rejected` error when pushing branches that include `.github/workflows/` file changes
- Falls back to `github.token` if `SYNC_PAT` is not configured

## Test plan
- [ ] Add a `SYNC_PAT` secret to the repo with `repo` and `workflow` scopes
- [ ] Trigger the sync-upstream workflow and verify it can push branches containing workflow file changes
- [ ] Verify the PR creation and auto-merge steps use the PAT correctly

Fixes #24